### PR TITLE
[10435] Adjust SME calculation for specific column

### DIFF
--- a/src/main/resources/db/migration/R__1.00.00_OTEXA_Annual_Opt_HTS_VW.sql
+++ b/src/main/resources/db/migration/R__1.00.00_OTEXA_Annual_Opt_HTS_VW.sql
@@ -27,7 +27,10 @@ SELECT details.[Country]
     , hts.[LONG_HTS] as 'HTS'
     , chapter.[LONG_CHAPTER] as 'Chapter'
     , hdr.[HEADER_DESCRIPTION] as 'DATA_KEY'
-    , details.[VAL] / details.[SYEF] AS 'DATA_VALUE'
+    , CASE 
+        WHEN hdr.[HEADER_DESCRIPTION] = '20-Apr' THEN details.[VAL] * details.[SYEF]
+        ELSE details.[VAL] / details.[SYEF]
+        END as 'DATA_VALUE'
     , 'UNITS' as 'DATA_TYPE'
 FROM [dbo].[OTEXA_ANNUAL] details
 INNER JOIN [dbo].[OTEXA_HEADER_REF] hdr
@@ -50,7 +53,10 @@ SELECT details.[Country]
     , hts.[LONG_HTS] as 'HTS'
     , chapter.[LONG_CHAPTER] as 'Chapter'
     , hdr.[HEADER_DESCRIPTION] as 'DATA_KEY'
-    , details.[VAL] * details.[SYEF] AS 'DATA_VALUE'
+    , CASE 
+        WHEN hdr.[HEADER_DESCRIPTION] = '20-Apr' THEN details.[VAL]
+        ELSE details.[VAL] * details.[SYEF]
+        END AS 'DATA_VALUE'
     , 'SME' as 'DATA_TYPE'
 FROM [dbo].[OTEXA_ANNUAL] details
 INNER JOIN [dbo].[OTEXA_HEADER_REF] hdr


### PR DESCRIPTION
* The DG-28 column (`20-Apr`) should be multiplied by SYEF when units (`DATA_KEY`) is `SME`.
* The DG-28 column (`20-Apr`) should not be converted when units (`DATA_KEY`) is `UNITS`.