### PR TITLE
[12348] Major Shippers Report (No Filter views) - Enable two default landing pages

### DIFF
--- a/client/src/reports/OtexaAnnual.vue
+++ b/client/src/reports/OtexaAnnual.vue
@@ -139,8 +139,8 @@ export default {
     onlyCountry: null
   }),
   async created () {
-    this.onlyCountry = this.$route.query.onlyCountry
-      ? this.$route.query.onlyCountry === 'true'
+    this.onlyCountry = (this.$route.query.onlyCountry || this.reportName.includes('Category'))
+      ? (this.$route.query.onlyCountry === 'true' || this.reportName.includes('Country'))
       : true
 
     let source = this.reportName.includes('Footwear')


### PR DESCRIPTION
- Want for one URL to lead to a view that starts with pre-filtering by Category, and another that pre-filters by Country