### PR TITLE
[15146] DG28/Current Month: SYEF/SME conversion

### DIFF
--- a/src/main/resources/db/migration/R__1.00.03_OTEXA_Annual_VW.sql
+++ b/src/main/resources/db/migration/R__1.00.03_OTEXA_Annual_VW.sql
@@ -53,7 +53,10 @@ SELECT details.[Country]
     , hts.[LONG_HTS] as 'HTS'
     , chapter.[LONG_CHAPTER] as 'Chapter'
     , hdr.[HEADER_DESCRIPTION] as 'DATA_KEY'
-    , details.[VAL] * details.[SYEF] AS 'DATA_VALUE'
+    , CASE 
+        WHEN hdr.[HEADER_DESCRIPTION] = 'Current Month' and 'Category' LIKE '%M2.%' THEN details.[VAL]
+        ELSE details.[VAL] * details.[SYEF]
+        END as 'DATA_VALUE'
     , 'SME' as 'DATA_TYPE'
 FROM [dbo].[OTEXA_ANNUAL] details
 INNER JOIN [dbo].[OTEXA_HEADER_REF] hdr


### PR DESCRIPTION
For DG28/"Current Month", if the category contains `M2.`, it's already in SME