### PR TITLE
[17720] Otexa Footwear - Adjust for missing Categories in HTS Ref

### DIFF
--- a/src/main/resources/db/migration/R__1.00.02_CreateOtexaHtsRefVw.sql
+++ b/src/main/resources/db/migration/R__1.00.02_CreateOtexaHtsRefVw.sql
@@ -2,6 +2,7 @@ CREATE OR ALTER VIEW [dbo].[OTEXA_HTS_REF_VW]
 AS
     SELECT hts.[HTS], hts_cat.[CAT_ID], CONCAT(hts.[HTS], ' - ', hts.[DESCRIPTION]) as 'LONG_HTS'
     FROM [dbo].[OTEXA_HTS_REF] hts
-    INNER JOIN [dbo].[OTEXA_HTS_CAT_REF] hts_cat
+    RIGHT JOIN [dbo].[OTEXA_HTS_CAT_REF] hts_cat
     ON hts.HTS = hts_cat.HTS
+    WHERE hts.HTS IS NOT NULL
 GO


### PR DESCRIPTION
- OTEXA_HTS_REF does not include CAT_ID < 200, so we need to include it from OTEXA_HTS_CAT_REF, but exclude rows where HTS is null since this results in double counting of some HTS codes