### PR TITLE
[19335] Otexa: Derive HTS-Category associations from the data rather …

### DIFF
--- a/src/main/resources/db/migration/R__1.00.02_CreateOtexaHtsRefVw.sql
+++ b/src/main/resources/db/migration/R__1.00.02_CreateOtexaHtsRefVw.sql
@@ -1,8 +1,7 @@
 CREATE OR ALTER VIEW [dbo].[OTEXA_HTS_REF_VW]
 AS
-    SELECT hts.[HTS], hts_cat.[CAT_ID], CONCAT(hts.[HTS], ' - ', hts.[DESCRIPTION]) as 'LONG_HTS'
+    SELECT hts_cat.[HTS], hts_cat.[CAT_ID], CONCAT(hts_cat.[HTS], ' - ', hts.[DESCRIPTION]) as 'LONG_HTS'
     FROM [dbo].[OTEXA_HTS_REF] hts
-    RIGHT JOIN [dbo].[OTEXA_HTS_CAT_REF] hts_cat
+    FULL OUTER JOIN [dbo].[OTEXA_HTS_CAT_REF] hts_cat
     ON hts.HTS = hts_cat.HTS
-    WHERE hts.HTS IS NOT NULL
 GO


### PR DESCRIPTION
…than the ref table

- This will fix the issue in which some Categories for Annual Footwear were not returning an HTS code
- If an HTS description is present in OTEXA_HTS_REF, then it will be used, but absence from that table won't prevent it from being part of the reporting views