### PR TITLE
[20121] OtexaAnnual/Footwear Interactive edit World filter

### DIFF
--- a/client/src/reports/OtexaAnnual.vue
+++ b/client/src/reports/OtexaAnnual.vue
@@ -359,17 +359,13 @@ export default {
         filters.push(this.filter('Display In', 'In', [this.displayIn], true, true))
       }
 
-      if (allSelectedCountries.length === 0) {
-        filters.push(this.filter('Country', 'All', [], false))
-      } else {
+      if (allSelectedCountries.length > 0) {
         let selectedCountries = this.countries
           .filter(c => allSelectedCountries.includes(c.ctryId))
           .map(c => c.ctryDescription.trim())
-        if ( selectedCountries.includes('World') || selectedCountries.includes('WORLD') ) {
-          filters.push(this.filter('Country', 'All', [], false))
-        } else {
-          filters.push(this.filter('Country', 'In', selectedCountries, false, true))
-        }
+        filters.push(this.filter('Country', 'In', selectedCountries, false, true))
+      } else {
+        filters.push(this.filter('Country', 'All', [], false))
       }
 
       if (this.selectedCategories.length > 0) {

--- a/client/src/reports/OtexaAnnualFootwearDivided.vue
+++ b/client/src/reports/OtexaAnnualFootwearDivided.vue
@@ -349,17 +349,13 @@ export default {
         filters.push(this.filter('Display In', 'In', [this.displayIn], true, true))
       }
 
-      if (allSelectedCountries.length === 0) {
-        filters.push(this.filter('Country', 'All', [], false))
-      } else {
+      if (allSelectedCountries.length > 0) {
         let selectedCountries = this.countries
           .filter(c => allSelectedCountries.includes(c.ctryId))
           .map(c => c.ctryDescription.trim())
-        if ( selectedCountries.includes('World') || selectedCountries.includes('WORLD') ) {
-          filters.push(this.filter('Country', 'All', [], false))
-        } else {
-          filters.push(this.filter('Country', 'In', selectedCountries, false, true))
-        }
+        filters.push(this.filter('Country', 'In', selectedCountries, false, true))
+      } else {
+        filters.push(this.filter('Country', 'All', [], false))
       }
 
       if (this.selectedCategories.length > 0) {


### PR DESCRIPTION
- Restore original behavior of not including all the countries in the World
- Also applies to the special "Divided" template