### PR TITLE
[27115] Fix Filter Stacking on reports where filter pane is visible

### DIFF
--- a/client/src/reports/OtexaAnnual.vue
+++ b/client/src/reports/OtexaAnnual.vue
@@ -430,6 +430,7 @@ export default {
         type: 'report',
         tokenType: this.pbi.models.TokenType.Embed,
         permissions: this.pbi.models.Permissions.All,
+        filters: filters,
         settings: {
           filterPaneEnabled: true,
           navContentPaneEnabled: false,
@@ -444,8 +445,6 @@ export default {
         this.loadingReport = false
         this.setTokenExpirationListener(this.report.powerBiToken.expiration)
         embedContainer.children[0].style.height = null;
-
-        report.setFilters(filters)
 
           let pages = await report.getPages()
           let htsPage = pages.filter(p => p.displayName === 'HTS')[0]

--- a/client/src/reports/OtexaExports.vue
+++ b/client/src/reports/OtexaExports.vue
@@ -471,6 +471,7 @@ export default {
         type: 'report',
         tokenType: this.pbi.models.TokenType.Embed,
         permissions: this.pbi.models.Permissions.All,
+        filters: filters,
         settings: {
           filterPaneEnabled: true,
           navContentPaneEnabled: false,
@@ -487,7 +488,6 @@ export default {
         this.setTokenExpirationListener(this.report.powerBiToken.expiration)
         embedContainer.children[0].style.height = null;
 
-        report.setFilters(filters)
         let pages = await report.getPages()
         let countryPage = pages.filter(p => p.displayName === 'Country')[0]
         let scheduleBPage = pages.filter(p => p.displayName === 'Schedule B')[0]

--- a/src/main/resources/db/migration/R__1.00.48_OtexaHtsChapterRefView.sql
+++ b/src/main/resources/db/migration/R__1.00.48_OtexaHtsChapterRefView.sql
@@ -14,5 +14,6 @@ AS
         ON mapping.CHAPTER = c.CHAPTER
     LEFT OUTER JOIN [OTEXA_HTS_REF] hts
         ON mapping.HTS = hts.HTS
+        AND mapping.CAT_ID = hts.CAT_ID
     WHERE mapping.HTS is NOT NULL
 GO


### PR DESCRIPTION
Fixed issue where filters would stack when a user would set filters, view report, go back to filter's screen, set new filters, then view report again.