### PR TITLE
[28365] Fix OTEXA Annual View Category 900 Value Calculation

### DIFF
--- a/src/main/resources/db/migration/R__1.00.03_OTEXA_Annual_VW.sql
+++ b/src/main/resources/db/migration/R__1.00.03_OTEXA_Annual_VW.sql
@@ -41,6 +41,7 @@ SELECT details.[CTRYNUM]
     , chapter.[LONG_CHAPTER] as 'Chapter'
     , hdr.[HEADER_DESCRIPTION] as 'DATA_KEY'
     , CASE 
+        WHEN details.[CAT_ID] = 900 AND hdr.[HEADER_TYPE] = 'SME' THEN 0
         WHEN hdr.[HEADER_DESCRIPTION] = 'Current Month' THEN details.[VAL]
         ELSE details.[VAL] / details.[SYEF]
         END as 'DATA_VALUE'


### PR DESCRIPTION
OTEXA Annual Data reports are failing to refresh due to a SQL divide by zero error, that comes from Category 900 data points having a value but having a conversion factor of zero. 